### PR TITLE
Minor cleanups, accept or reject as desired. Includes:

### DIFF
--- a/draft-huitema-quic-dnsoquic.md
+++ b/draft-huitema-quic-dnsoquic.md
@@ -49,6 +49,13 @@
       city = "Oxford"
       code = "OX4 4GA"
       country = "U.K."
+    [[author]]
+    initials="J."
+    surname="Iyengar"
+    fullname="Jana Iyengar"
+    organization = "Google"
+      [author.address]
+      email = "jri@google.com"
 
 %%%
 
@@ -57,10 +64,10 @@
 
 This document describes the use of QUIC to provide transport privacy
 for DNS.  The encryption provided by QUIC has similar properties to
-that provided by TLS, while QUIC transport eliminates the end-of-
-queue blocking issues inherent with TCP and provides more efficient
+that provided by TLS, while QUIC transport eliminates the 
+head-of-line blocking issues inherent with TCP and provides more efficient
 error corrections than UDP.  DNS over QUIC has privacy properties
-similar to DNS over TLS specified in RFC 7858, and performance
+similar to DNS over TLS specified in RFC7858, and performance
 similar to classic DNS over UDP.
 
 {mainmatter}
@@ -75,27 +82,28 @@ transport [@!I-D.ietf-quic-transport].  The goals of this mapping are:
     [@?RFC7858].
 
 2.  Explore the potential performance gains of using QUIC as a DNS
-    transport, versus other solutions like QUIC over UDP [@!RFC1035] or
+    transport, versus other solutions like DNS over UDP [@!RFC1035] or
     DNS over TLS [@?RFC7858].
 
 3.  Participate in the definition of QUIC protocols and API, by
     outlining a use case for QUIC different from HTTP over QUIC
     [@?I-D.ietf-quic-http].
 
-In order to achieve these goals, we will focus on the "stub to
-recursive resolver" scenario also addressed by [@?RFC7858], and we will
-list specific non-goals:
+In order to achieve these goals, the focus is limited to the "stub to
+recursive resolver" scenario also addressed by [@?RFC7858], that is
+the protocol described here works for queries and responses between
+stub clients and recursive servers. The specific non-goals are:
 
-1.  We will not attempt to support zone transfers [@?RFC5936], as these
+1.  No attempt is made to support zone transfers [@?RFC5936], as these
     are not relevant to the stub to recursive resolver scenario.
 
-2.  We will not attempt to evade potential blocking of DNS over QUIC
+2.  No attempt is made to evade potential blocking of DNS over QUIC
     traffic by middle boxes.
 
 Users interested in zone transfers should continue using TCP based
-solutions, and users interested in evading middle-boxes should
+solutions, and users interested in evading middleboxes should
 consider using solutions like DNS over HTTPS or DNS over HTTP over
-QUIC.
+QUIC (TODO: References required).
 
 Specifying the transmission of an application over QUIC requires to
 specify how the application messages are mapped to QUIC streams, and
@@ -103,17 +111,24 @@ generally how the application will use QUIC.  This is done for HTTP
 in [@?I-D.ietf-quic-http].  The purpose of this document is to define
 the way DNS can be transmitted over QUIC.
 
-In this document, Section 2 presents the reasoning that guided our
-design.  Section 3 specifies the actual mapping of DNS over QUIC.
-Section 4 presents guidelines on the usage and deployment of DNS over
-QUIC.
+In this document, (#design-considerations) presents the reasoning that guided 
+our design.  (#specifications) specifies the actual mapping of DNS over QUIC.
+(#usage-and-deployment) presents guidelines on the usage and deployment of DNS 
+overQUIC.
 
 
-## Requirements
+## Key words
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in [@!RFC2119].
+
+# Terminology
+
+The term DNS/QUIC is used interchangeably with 'DNS over QUIC' throughout 
+this document.
+
+TODO: Make this usage more consistent.
 
 # Design Considerations
 
@@ -121,23 +136,23 @@ document are to be interpreted as described in [@!RFC2119].
    were used for the proposed mapping of DNS over QUIC.  This section is
    informative in nature.
 
-## Focus on the stub to resolver scenario
+## Scope is limited to the stub to resolver scenario
 
-   We can broadly classify the DNS protocol usage scenario in three
+   Usage scenarios for the DNS protocol can be broadly classified in three
    groups: stub to recursive resolver, recursive resolver to
-   authoritative, and server to server.  Our design focuses on the "stub
+   authoritative server, and server to server.  Our design focuses on the "stub
    to recursive resolver" scenario, and specifically to the scenario in
    which the choice of recursive resolver is manually configured in the
    stub.  In this case, the configuration will specify the name of the
    resolver, its address, how security credentials are verified, and of
    course the use of QUIC as a transport.
 
-   We will not address the scenario in which the stub dynamically
+   No attempt is made to address the scenario in which the stub dynamically
    discovers the resolver using DHCP or IPv6 Router Advertisements.
    These scenarios would require a way to dynamically signal support for
    QUIC transport in these resolvers.  This is left for future study.
 
-   We will also not address the recursive to authoritative scenarios.
+   No attempt is made to address the recursive to authoritative scenarios.
    Authoritative resolvers are discovered dynamically through NS
    records.  In the absence of an agreed way for authoritative to signal
    support for QUIC transport, recursive resolvers would have to resort
@@ -151,14 +166,14 @@ document are to be interpreted as described in [@!RFC2119].
    creates a unique profile, in which a query results in several
    responses.  Supporting that profile would complicate the mapping of
    DNS queries over QUIC streams.  Zone transfers are not used in the
-   stub to recursive scenario that we focus on, and seem to be currently
-   well served by the DNS over TCP.  We will not attempt to support them
+   stub to recursive scenario that is the focus here, and seem to be currently
+   well served by the DNS over TCP.  There is no attempt to support them
    in this proposed mapping of DNS to QUIC.
 
-## Meet Privacy Requirements
+## Provide DNS Privacy
 
   DNS privacy considerations are described in [@?RFC7626].  [@?RFC7858]
-  defines how to mitigate these issues by transmitting DNS messages
+  defines how to mitigate some of these issues by transmitting DNS messages
   over TLS and TCP.  QUIC connection setup includes the negotiation of
   security parameters using TLS, as specified in [@!I-D.ietf-quic-tls],
   enabling encryption of the QUIC transport.  Transmitting DNS messages
@@ -170,28 +185,31 @@ document are to be interpreted as described in [@!RFC2119].
  queries and HTTP responses.  This is achieved through three main
  components:
 
- 1.  Support for 0-RTT data during session resume,
+ 1.  Support for 0-RTT data during session resume.
 
  2.  Support for advanced error recovery procedures as specified in
      [@?I-D.ietf-quic-recovery].
 
- 3.  Mitigation of head-of-queue blocking by allowing parallel
+ 3.  Mitigation of head-of-line blocking by allowing parallel
      delivery of data on multiple streams.
 
- The mapping of DNS to QUIC will take advantage of these features in
- three ways:
+The mapping of DNS to QUIC will take advantage of these features in
+three ways:
 
- 1.  Optional support for sending 0-RTT data during session resume,
+ 1.  Optional support for sending 0-RTT data during session resume
+     (the security and privacy implications of this are discussed 
+     in later sections).
 
- 2.  Long duration sessions carrying several DNS transactions,
+ 2.  Long-lived connections over which multiple DNS transactions
+     are performed,
      generating the sustained traffic required to benefit from
-     advanced recovery features,
+     advanced recovery features.
 
  3.  Mapping of each DNS Query/Response exchange to a separate stream,
-     to mitigate head of queue blocking.
+     to mitigate head-of-line blocking.
 
  These considerations will be reflected in the mapping of DNS traffic
- to QUIC streams in Section 3.2.
+ to QUIC streams in (#stream-mapping-and-usage).
 
 ## Development of QUIC protocols and API
 
@@ -209,13 +227,13 @@ document are to be interpreted as described in [@!RFC2119].
  of the requests and responses according to various policies and
  priorities, and can tightly control the usage of streams.  This comes
  at the cost of some complexity, and also some performance since the
- control stream is exposed to head of queue blocking.
+ control stream is exposed to head-of-line blocking.
 
- We want to deliberately explore a different design, in which there is
+ In this document a different design is deliberately explored, in which there is
  no control stream.  Clients and servers can initiate queries as
  determined by the DNS application logic, opening new streams as
  necessary.  This provides for maximum parallelism between queries, as
- noted in Section 2.3.  It also places constraints on the API.
+ noted in (#design-for-minimum-latency).  It also places constraints on the API.
  Instead of merely listening for control messages on a control stream,
  client and servers will have to be notified of the opening of a new
  stream by their peer.  Instead of orderly closing the control stream,
@@ -229,11 +247,11 @@ document are to be interpreted as described in [@!RFC2119].
  Being different from HTTP over QUIC is a design choice.  The
  advantage is that the mapping can be defined for minimal overhead and
  maximum performance.  The downside is that the difference can be
- noted by firewall and middleboxes.  There may be environments in
+ noted by firewalls and middleboxes.  There may be environments in
  which HTTP over QUIC will be allowed, but DNS over QUIC will be
  disallowed and blocked by these middle boxes.
 
- We are conscious that this might be a problem, but we have no
+ It is recognised that this might be a problem, but there is currently no
  indication on how widespread that problem might be.  It might be that
  the problem will be so acute that the only realistic solution would
  be to communicate with independent recursive resolvers using DNS over
@@ -272,15 +290,16 @@ string "hq-h00".
 ### Port Selection
 
 By default, a DNS server that supports DNS/QUIC MUST listen for and
-accept QUIC connections on UDP port 853, unless it has mutual
-agreement with its clients to use a port other than 853 for DNS over
-QUIC.  In order to use a port other than 853, both clients and
+accept QUIC connections on the dedicated UDP port TBD (number to be
+defined in (#iana-considerations), unless it has mutual
+agreement with its clients to use a port other than TBD for DNS over
+QUIC.  In order to use a port other than TBD, both clients and
 servers would need a configuration option in their software.
 
 By default, a DNS client desiring to use DNS over QUIC with a
-particular server MUST establish a QUIC connection to UDP port 953 on
+particular server MUST establish a QUIC connection to UDP port TBD on
 the server, unless it has mutual agreement with its server to use a
-port other than port 953 for DNS over QUIC.  Such another port MUST
+port other than port TBD for DNS over QUIC.  Such another port MUST
 NOT be port 53 or port 853.  This recommendation against use of port
 53 for DNS over QUIC is to avoid confusion between DNS over QUIC and
 DNS over UDP as specified in [@!RFC1035].  Similarly, using port 853
@@ -290,13 +309,12 @@ specified in [@!RFC1035].
 ## Stream Mapping and Usage
 
 The mapping of DNS traffic over QUIC streams takes advantage of the
-QUIC stream features detailed in section 10 of
-[@!I-D.ietf-quic-transport].
+QUIC stream features detailed in Section 10 of [@!I-D.ietf-quic-transport].
 
 The stub to resolver DNS traffic follows a simple pattern in which
-the client emits a query, and the server provides a response.  In
+the client sends a query, and the server provides a response.  In
 this case the client MUST select the next available client stream, in
-conformance with section 10.2 of [@!I-D.ietf-quic-transport].
+conformance with Section 10.2 of [@!I-D.ietf-quic-transport].
 
 The client MUST send the DNS query over the selected stream, and MUST
 indicate through the STREAM FIN mechanism that no further data will
@@ -316,7 +334,7 @@ There are planned traffic patterns in which a server sends
 unsolicited queries to a client, such as for example PUSH messages
 defined in [@?I-D.ietf-dnssd-push].  When a server wishes to send such
 queries it MUST select the next available server stream, in
-conformance with section 10.2 of [@!I-D.ietf-quic-transport].  It will
+conformance with Section 10.2 of [@!I-D.ietf-quic-transport].  It will
 then send the DNS query over the selected stream, and MUST indicate
 through the STREAM FIN mechanism that no further data will be sent on
 that stream.
@@ -331,7 +349,7 @@ Stream transmission may be abandoned by either party, using the
 stream "reset" facility.  A stream reset indicates that one party is
 unwilling to continue processing the transaction associated with the
 stream.  The corresponding transaction MUST be abandoned.  A Server
-Failure (ServFail, [@!RFC1035]) SHOULD be notified to the initiator of
+Failure (SERVFAIL, [@!RFC1035]) SHOULD be notified to the initiator of
 the transaction.
 
 TODO: should there be timers?  What if a client sends a query and the
@@ -349,7 +367,7 @@ The transactions corresponding to stream number higher than indicated
 in the GO AWAY frames MUST be considered failed.  Similarly, if
 streams are still open when the CONNECTION_CLOSE is received, the
 corresponding transactions MUST be considered failed.  In both cases,
-a Server Failure (ServFail, [@!RFC1035]) SHOULD be notified to the
+a Server Failure (SERVFAIL, [@!RFC1035]) SHOULD be notified to the
 initiator of the transaction.
 
 ## Connection Resume and 0-RTT
@@ -359,7 +377,7 @@ mechanisms supported by QUIC transport [@!I-D.ietf-quic-transport] and
 QUIC TLS [@!I-D.ietf-quic-tls].  Stub resolvers SHOULD consider
 potential privacy issues associated with session resume before
 deciding to use this mechanism.  These privacy issues are detailed in
-Section 6.4.
+(#privacy-issues-with-session-resume).
 
 When resuming a session, a stub resolver MAY take advantage of the
 0-RTT mechanism supported by QUIC.  The 0-RTT mechanism MUST NOT be
@@ -369,29 +387,16 @@ transmit an Update.
 
 # Usage and deployment
 
-TODO: add deployment considerations here, such as how to provision
-the service, how to verify certificates, how to manage fallbacks.
-
 ## Authentication
 
-We envisage using DNS over QUIC in two main scenarios, client to to
-recursive resolver and recursive resolver to authoritative resolver.
-In the client to recursive resolver scenario, the authentication
+For the stub to recursive resolver scenario, the authentication
 requirements are the same as described in [@?RFC7858] and
 [@!I-D.ietf-dprive-dtls-and-tls-profiles].  There is no need to
 authenticate the client's identity in either scenario.
 
-In the recursive resolver to authoritative server scenario, the
-server's identity can be verified using the usual TLS mechanisms,
-using either X.509 certificate or the DANE mechanisms [@?RFC6698].  The
-server's authority to provide answers for the client's queries can be
-verified using DNS Security Extensions (DNSSEC) [@?RFC4033], and there
-is not much point to replicate that mechanism using QUIC security
-negotiation.
-
 ## Fall Back to other protocols
 
-If the establishment of the DNS over QUIC session fails, clients
+If the establishment of the DNS over QUIC connection fails, clients
 SHOULD attempt to fall back to DNS over TLS, as specified in
 [@?RFC7858].
 
@@ -400,7 +405,7 @@ DNS over QUIC, including timeouts, connection refusals, and QUIC
 handshake failures, and not request DNS over QUIC from them for a
 reasonable period (such as one hour per server).  DNS clients
 following an out-of-band key-pinned privacy profile ([@?RFC7858]) MAY
-be more aggressive about retrying DNS-over-QUIC connection failures.
+be more aggressive about retrying DNS over QUIC connection failures.
 
 ## Guidance on Connection Reuse, Close, and Reestablishment
 
@@ -409,7 +414,7 @@ and "gethostbyname()", current implementations are known to open and
 close TCP connections for each DNS query.  To avoid excess QUIC
 connections, each with a single query, clients SHOULD reuse a single
 QUIC connection to the recursive resolver.  Alternatively, they may
-prefer to use UDP to a DNS-over-QUIC-enabled caching resolver on the
+prefer to use UDP to a DNS over QUIC-enabled caching resolver on the
 same machine that then uses a system-wide QUIC connection to the
 recursive resolver.
 
@@ -431,7 +436,7 @@ values on idle connections.  Clients and servers should reuse and/or
 close connections depending on the level of available resources.
 Timeouts may be longer during periods of low activity and shorter
 during periods of high activity.  Current work in this area may also
-assist DNS-over-TLS clients and servers in selecting useful timeout
+assist DNS over TLS clients and servers in selecting useful timeout
 values [@?RFC7828] [@TDNS].
 
 Clients and servers that keep idle connections open MUST be robust to
@@ -441,7 +446,7 @@ due to resource constraints).  As with current DNS over TCP, clients
 MUST handle abrupt closes and be prepared to reestablish connections
 and/or retry queries.
 
-When reestablishing a DNS-over-QUIC connection that was terminated,
+When reestablishing a DNS over QUIC connection that was terminated,
 clients and servers SHOULD take advantage of the QUIC "resume"
 mechanisms.
 
@@ -457,19 +462,20 @@ those of DNS over TLS [@?RFC7858].
 
 # Privacy Considerations
 
-QUIC over TLS is specifically designed to protect the DNS traffic
+DNS over TLS is specifically designed to protect the DNS traffic
 between stub and resolver from observations by third parties, and
-thus protect the privacy of the stub's users.  However, the recursive
+thus protect the privacy of queries from the stub.  However, the recursive
 resolver has full visibility of the stub's traffic, and could be used
-as an observation point, as discussed in Section 6.1.  Also, the
-requests sent by the stub resolver may generate corresponding
-requests from the recursive resolver to authoritative servers.
+as an observation point, as discussed in (#backend-observation-of-dns-traffic).  
+Also, the
+queries sent by the stub resolver may generate corresponding
+queries from the recursive resolver to authoritative servers.
 Adversaries can try to infer the stub to resolver traffic from their
 observation of the resolver to authoritative traffic, as disccused in
-Section 6.2.
+(#backend-observation-of-dns-traffic).
 
 QUIC incorporates the mechanisms of TLS 1.3 [@?I-D.ietf-tls-tls13] and
-this enables QUIC enables transmission of "Zero RTT" data.  This can
+this enables QUIC transmission of "Zero RTT" data.  This can
 provide interesting latency gains, but it raises two concerns:
 
 1.  Adversaries could replay the zero-RTT data and infer its content
@@ -478,7 +484,8 @@ provide interesting latency gains, but it raises two concerns:
 2.  The zero-RTT mechanism relies on TLS resume, which can provide
     linkability between successive client sessions.
 
-We develop these issues in Section 6.3 and Section 6.4.
+These issues are developed (#privacy-issues-with-0rtt-data) and 
+(#privacy-issues-with-session-resume).
 
 ## Privacy of Resolver Data
 
@@ -517,18 +524,19 @@ reduce the effectiveness of this attack.  Stub clients MAY prefer
 using resolvers that manage a large number of other clients, as this
 will make the adversaries job harder.  In the future, stub clients
 MAY attempt to mitigate this issue by using the cover traffic and
-split traffic strategies discussed in Section 6.1.
+split traffic strategies discussed in (#privacy-of-resolver-data).
 
 ## Privacy Issues With 0RTT data
 
 The zero-RTT data can be replayed by adversaries.  That data may
-triggers a request by a recursive resolver to an authoritative
+triggers a query by a recursive resolver to an authoritative
 resolvers.  Adversaries may be able to pick a time at which the
 recursive resolver outgoing traffic is observable, and thus find out
 what name was queried for in the 0-RTT data.
 
 This risk is in fact a subset of the general problem of observing the
-behavior of the recursive resolver discussed in Section 6.2.  The
+behavior of the recursive resolver discussed in 
+(#backend-observation-of-dns-traffic).  The
 attack is partially mitigated by reducing the observability of this
 traffic.  However, the risk is amplified for 0-RTT data, because the
 attacker might replay it at chosen times, several times.
@@ -542,17 +550,16 @@ the user clearly understands the associated risks.
 The QUIC session resume mechanism reduces the cost of reestablishing
 sessions and enables zero-RTT data.  There is a linkability issue
 associated with session resume, if the same resume token is used
-
 several times, but this risk is mitigated by the mechanisms
 incorporated in QUIC and in TLS 1.3.  With these mechanisms, clients
 and servers can cooperate to avoid linkability by third parties.
 However, the server will always be able to link the resumed session
 to the initial session.  This creates a virtual long duration
-session.  The series of requests in that section can be used by the
+session.  The series of queries in that session can be used by the
 server to identify the client.
 
 Enabling the server to link client sessions through session resume is
-probably not a large addiional risk if the client's connectivity did
+probably not a large additional risk if the client's connectivity did
 not change between the sessions, since the two sessions can probably
 be correlated by comparing the IP addresses.  On the other hand, if
 the addresses did change, the client SHOULD consider whether the
@@ -576,16 +583,18 @@ obviously depend on the level of trust between stub and recursive.
 
    Specification:  This document
 
-## Reservation of port 953
+## Reservation of dedicated port
 
    IANA is required to add the following value to the "Service Name and
    Transport Protocol Port Number Registry" in the System Range.  The
    registry for that range requires IETF Review or IESG Approval
    [@?RFC6335], and such a review was requested using the early allocation
-   process [@?RFC7120] for the well-known TCP port in this document.
+   process [@?RFC7120] for the well-known UDP port in this document. Since
+   port 853 is reserved for 'DNS query-response protocol run over TLS' 
+   consideration is requested for reserving port 953 for 'DNS query-response 		  
+   protocol run over QUIC'.
 
        Service Name           domain-s
-       Port Number            953
        Transport Protocol(s)  TCP/UDP
        Assignee               IESG
        Contact                IETF Chair


### PR DESCRIPTION
- add Jana as an author
- be more consistent with DNS-over-QUIC vs DNS over QUIC vs DNS/QUIC. More to do on this (what do we prefer?)
- use 'head-of-line' blocking to match the term used in the QUIC protocol draft
- fix some section referencing
- make text more abstract by removing 'we' (personal preference)
- copy what RFC7858 did when making early port request by using 'TBD'