### PR TITLE
Wordsmith flow control recommendation.

### DIFF
--- a/draft-ietf-dprive-dnsoquic.md
+++ b/draft-ietf-dprive-dnsoquic.md
@@ -554,12 +554,13 @@ connections. For example:
 
 Servers and Clients manage flow control as specified in QUIC.
 
-Servers MAY use the "maximum stream ID" parameter of the QUIC transport to limit
+Servers can use the "maximum stream ID" parameter of the QUIC transport to limit
 the number of streams opened by the client. This mechanism will effectively
 limit the number of DNS queries that a client can send on a single DoQ
 connection. The initial value of this parameter is specified by the transport
-parameter `initial_max_streams_bidi`. For better performance, it is RECOMMENDED
-that servers chose a sufficiently large value for this parameter.
+parameter `initial_max_streams_bidi`. To allow at least one query per client,
+servers SHOULD use a non-zero value for this parameter. Using larger values
+will result in better performance.
 
 The flow control mechanisms of QUIC control how much data can be sent by QUIC
 nodes at a given time. The initial values of per stream flow control parameters
@@ -574,7 +575,8 @@ is defined by two transport parameters:
   a MAX_STREAM_DATA frame.
 
 For better performance, it is RECOMMENDED that clients and servers set each of
-these two parameters to a value of 65535 or greater.
+these two parameters to a value of 65537 or greater, allowing for at least one
+query or response of maximum length 65535 bytes.
 
 # Implementation Status
 

--- a/draft-ietf-dprive-dnsoquic.md
+++ b/draft-ietf-dprive-dnsoquic.md
@@ -557,14 +557,15 @@ section 4 of {{!RFC9000}}. These mechanisms allows clients and servers to
 how many streams can be created, how much data can be sent on a stream,
 and how much data can be sent on the union of all streams. For DNS over QUIC,
 controlling how many streams are created allow servers to control how many
-new requests the client can send on a given connection.
+new requests the client can send on a given connection. 
 
-The global and per stream flow control allow servers to control how much data can be sent by
-clients. If that control is strict, clients will have to wait for new credits
-before they can transmit the full content of the request. The same mechanisms
-allow clients to control how much data can be sent by servers. If too strict,
-servers will have to wait for credits before sending the full content of the
-responses.
+Flow control exists to protect endpoint resources.
+For servers, global and per-stream flow control limits control how much data can be sent by
+clients. The same mechanisms
+allow clients to control how much data can be sent by servers.
+Values that are too small will unnecessarily limit performance.
+Values that are too large might expose endpoints to overload or memory exhaustion.
+Implementations or deployments will need to adjust flow control limits to balance these concerns.
 
 Initial values of parameters control how many requests and how much data can be
 sent by clients and servers at the beginning of the connection. These values

--- a/draft-ietf-dprive-dnsoquic.md
+++ b/draft-ietf-dprive-dnsoquic.md
@@ -552,31 +552,27 @@ connections. For example:
 
 ## Flow Control Mechanisms
 
-Servers and Clients manage flow control as specified in QUIC.
+Servers and Clients manage flow control using the mechanisms defined in
+section 4 of {{!RFC9000}}. These mechanisms allows clients and servers to
+how many streams can be created, how much data can be sent on a stream,
+and how much data can be sent on the union of all streams. For DNS over QUIC,
+controlling how many streams are created allow servers to control how many
+new requests the client can send on a given connection.
 
-Servers can use the "maximum stream ID" parameter of the QUIC transport to limit
-the number of streams opened by the client. This mechanism will effectively
-limit the number of DNS queries that a client can send on a single DoQ
-connection. The initial value of this parameter is specified by the transport
-parameter `initial_max_streams_bidi`. To allow at least one query per client,
-servers SHOULD use a non-zero value for this parameter. Using larger values
-will result in better performance.
+The global and per stream flow control allow servers to control how much data can be sent by
+clients. If that control is strict, clients will have to wait for new credits
+before they can transmit the full content of the request. The same mechanisms
+allow clients to control how much data can be sent by servers. If too strict,
+servers will have to wait for credits before sending the full content of the
+responses.
 
-The flow control mechanisms of QUIC control how much data can be sent by QUIC
-nodes at a given time. The initial values of per stream flow control parameters
-is defined by two transport parameters:
-
-* initial_max_stream_data_bidi_local: when set by the client, specifies the
-  amount of data that servers can send on a "response" stream without waiting
-  for a MAX_STREAM_DATA frame.
-
-* initial_max_stream_data_bidi_remote: when set by the server, specifies the
-  amount of data that clients can send on a "query" stream without waiting for
-  a MAX_STREAM_DATA frame.
-
-For better performance, it is RECOMMENDED that clients and servers set each of
-these two parameters to a value of 65537 or greater, allowing for at least one
-query or response of maximum length 65535 bytes.
+Initial values of parameters control how many requests and how much data can be
+sent by clients and servers at the beginning of the connection. These values
+are specified in transport parameters exchanged during the connection handshake.
+The parameter values received in the initial connection also control how many requests and
+how much data can be sent by clients using 0-RTT data in a resumed connection.
+Using too small values of these initial parameters would restrict the
+usefulness of allowing 0-RTT data.
 
 # Implementation Status
 


### PR DESCRIPTION
Additional PR to address comments from @martinthomson on PR #58.

The current text is not definitive, may need a bit more massaging.

I have two concerns: that QUIC stacks, by default, will present default TP values designed for H3, which may or may not result in good performance for DoQ; and, that clients could pick inadequate values for the initial per stream control and global flow control, causing a sort of slow loris attack on servers.

Good performance require that client can submit queries without being unduly blocked by flow control. 

Servers should provide clients with at least some stream credits, allowing as many simultaneous transactions, and with enough per stream and global flow control credits -- enough meaning stream credits sufficient to encode the average length query. Currently, servers accept queries over UDP, with a typical maximum size of 1536 bytes, and servers have no way to control the arrival rate of UDP queries. On TCP, the servers will typically allow an initial window IW=10 packets. It would make sense for servers to allow creation of at least 10 streams, credits of 1536 bytes per stream, and global credits of 1536 bytes time number of allowed stream.

Clients should not by default block the transmission of responses by the server. On average, each response today fits on a UDP packet of maybe 1536 bytes, but the actual limit is 65535 bytes, plus two bytes for the length field. So we have two plausible values for the per stream initial window: 1536, or 65537. Clients should provide enough global flow control credits to let the server respond to all the queries sent by the client.