### PR TITLE
Opening unexpected streams is an error

### DIFF
--- a/draft-ietf-dprive-dnsoquic.md
+++ b/draft-ietf-dprive-dnsoquic.md
@@ -383,6 +383,8 @@ messages during a transaction. These include (but are not limited to)
 * an implementation receives a message containing the edns-tcp-keepalive
   EDNS(0) Option {{!RFC7828}} (see
   {{resource-management-and-idle-timeout-values}})
+* a client or a server attempts to open an unidirectional QUIC stream
+* a server attempts to open a server-initiated bidirectional QUIC sream
 
 If a peer encounters such an error condition it is considered a fatal error. It
 SHOULD forcibly abort the connection using QUIC's CONNECTION_CLOSE mechanism,


### PR DESCRIPTION
This addresses issue #82, What happens if I send unidirectional stream data? Answer: this is a protocol error.

Close #82