### PR TITLE
How can a server send a SERVFAIL if the connection has failed?

### DIFF
--- a/draft-ietf-dprive-dnsoquic.md
+++ b/draft-ietf-dprive-dnsoquic.md
@@ -436,10 +436,8 @@ QUIC's CONNECTION_CLOSE mechanism, and use the DoQ error code DOQ_NO_ERROR.
 Clients and servers MAY close the connection for a variety of other
 reasons, indicated using QUIC's CONNECTION_CLOSE. Client and servers
 that send packets over a connection discarded by their peer MAY
-receive a stateless reset indication. If a connection fails,
-all queries in progress over the connection MUST be considered failed,
-and a Server Failure (SERVFAIL, {{!RFC1035}}) SHOULD be notified
-to the initiator of the transaction.
+receive a stateless reset indication. If a connection fails, all the
+in progress transaction on that connection MUST be abandoned.
 
 ## Session Resumption and 0-RTT
 


### PR DESCRIPTION
 Let's make this text consistent with other text on abandoning transactions. If there is another failure scenario here where a SERVFAIL should be sent it needs to be clearer.