### PR TITLE
Revise security section after PHB comments.

### DIFF
--- a/draft-ietf-dprive-dnsoquic.md
+++ b/draft-ietf-dprive-dnsoquic.md
@@ -792,7 +792,7 @@ The security considerations of DoQ should be comparable to those of DoT
 recursive resolver scenario, but the considerations about person-in-the-middle
 attacks, middleboxes and caching of data from clear text connections also
 apply for DoQ to the resolver to authoritative server scenario. 
-As stated in {{authentication}} the authentication requirements for securing zone transfer using DoQ are the same as those for zone transfer over DoT, therefore the general security considerations are entirely analogous to those described in {{!RFFC9103}.
+As stated in {{authentication}} the authentication requirements for securing zone transfer using DoQ are the same as those for zone transfer over DoT, therefore the general security considerations are entirely analogous to those described in {{!RFC9103}}.
 
 DoQ relies on QUIC, which itself relies on TLS 1.3 and thus supports by default
 the protections against downgrade attacks described in {{?BCP195}}.

--- a/draft-ietf-dprive-dnsoquic.md
+++ b/draft-ietf-dprive-dnsoquic.md
@@ -783,8 +783,23 @@ this include that DoQ
 
 # Security Considerations
 
+A general Threat Analysis of the Domain Name System is found in {{?RFC3833}}.
+This analysis was written before the development of DoT, DoH and DoQ, and
+probably needs to be updated.
+
 The security considerations of DoQ should be comparable to those of DoT
-{{?RFC7858}}.
+{{?RFC7858}}. DoT as specified in {{?RFC7858}} only addresses the stub to
+recursive resolver scenario, but the considerations about person-in-the-middle
+attacks, middleboxes and caching of data from clear text connections also
+apply for DoQ to the resolver to authoritative server scenario. 
+DoQ provides a form of "channel security" similar to that provided by TSIG
+{{?RFC8945}}, and as such addresses some of the concerns about Securing DNS
+Zone Replication expressed in {{Section 4.3 of RFC3833}}.
+
+DoQ relies on QUIC, which itself relies on TLS 1.3 and thus supports by default
+the protections against downgrade attacks described in {{?BCP195}}.
+QUIC specific issues and their mitigations are described in
+{{Section 21 of RFC9000}}. 
 
 
 # Privacy Considerations

--- a/draft-ietf-dprive-dnsoquic.md
+++ b/draft-ietf-dprive-dnsoquic.md
@@ -792,9 +792,7 @@ The security considerations of DoQ should be comparable to those of DoT
 recursive resolver scenario, but the considerations about person-in-the-middle
 attacks, middleboxes and caching of data from clear text connections also
 apply for DoQ to the resolver to authoritative server scenario. 
-DoQ provides a form of "channel security" similar to that provided by TSIG
-{{?RFC8945}}, and as such addresses some of the concerns about Securing DNS
-Zone Replication expressed in {{Section 4.3 of RFC3833}}.
+As stated in {{authentication}} the authentication requirements for securing zone transfer using DoQ are the same as those for zone transfer over DoT, therefore the general security considerations are entirely analogous to those described in {{!RFFC9103}.
 
 DoQ relies on QUIC, which itself relies on TLS 1.3 and thus supports by default
 the protections against downgrade attacks described in {{?BCP195}}.


### PR DESCRIPTION
This PR is meant to address the secdir review authored by PHB (Issue #146). The review covers a lot of issues:

1) DNS security leaves much to be desired. Maybe, but not something we can undertake in this document. I added a reference to RFC 3833, and a mention that an update of that RFC might be useful.

2) We do not discuss discovery of DoQ servers. Yes of course. There is an entire WG doing that -- ADD. Plus lots of work in progress for authoritative. I suppose we will say so in the discussion after a new draft is published.

3) Security section points to RFC 7868, but that RFC is 6 years old, and does not address recursive to authoritative or server to server. That's true. I added some text covering the authoritative and zone transfer scenarios, and also a pointer to RFC 9000 for the QUIC specific parts.

4) The privacy section could be folded as a confidentiality subsection of security considerations. Maybe, but this is a matter of taste, or opinions, so the PR does not address that.

5) Traffic analysis states the issue of packet sizes but does not do much about it. This is addressed in Pr #143 which returns RFC 8467 to a normative reference.

Overall, I think the combination of this PR, PR #143 and some online discussion will address the secdir review.

